### PR TITLE
Refactor javascript implementation to be more javascripty

### DIFF
--- a/ref/javascript/bech32.js
+++ b/ref/javascript/bech32.js
@@ -1,0 +1,85 @@
+var BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+var BECH32_GENERATOR = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+
+module.exports = {
+  decode: decode,
+  encode: encode,
+  BECH32_CHARSET: BECH32_CHARSET,
+  BECH32_GENERATOR: BECH32_GENERATOR
+};
+
+function polymod (values) {
+  var chk = 1;
+  for (var p = 0; p < values.length; ++p) {
+    var top = chk >> 25;
+    chk = (chk & 0x1ffffff) << 5 ^ values[p];
+    for (var i = 0; i < 5; ++i) {
+      if ((top >> i) & 1) {
+        chk ^= BECH32_GENERATOR[i];
+      }
+    }
+  }
+  return chk;
+}
+
+function hrpExpand (hrp) {
+  var ret = [];
+  var p;
+  for (p = 0; p < hrp.length; ++p) {
+    ret.push(hrp.charCodeAt(p) >> 5);
+  }
+  ret.push(0);
+  for (p = 0; p < hrp.length; ++p) {
+    ret.push(hrp.charCodeAt(p) & 31);
+  }
+  return ret;
+}
+
+function verifyChecksum (hrp, data) {
+  return polymod(hrpExpand(hrp).concat(data)) === 1;
+}
+
+function createChecksum (hrp, data) {
+  var values = hrpExpand(hrp).concat(data).concat([0, 0, 0, 0, 0, 0]);
+  var mod = polymod(values) ^ 1;
+  var ret = [];
+  for (var p = 0; p < 6; ++p) {
+    ret.push((mod >> 5 * (5 - p)) & 31);
+  }
+  return ret;
+}
+
+function encode (hrp, data) {
+  var combined = data.concat(createChecksum(hrp, data));
+  var ret = hrp + '1';
+  for (var p = 0; p < combined.length; ++p) {
+    ret += BECH32_CHARSET.charAt(combined[p]);
+  }
+  return ret;
+}
+
+function decode (bechString) {
+  var p;
+  for (p = 0; p < bechString.length; ++p) {
+    if (bechString.charCodeAt(p) < 32 || bechString.charCodeAt(p) > 126) {
+      return null;
+    }
+  }
+  var pos = bechString.lastIndexOf('1');
+  if (pos < 1 || pos + 7 > bechString.length || bechString.length > 90) {
+    return null;
+  }
+  var hrp = bechString.substring(0, pos);
+  var data = [];
+  for (p = pos + 1; p < bechString.length; ++p) {
+    var d = BECH32_CHARSET.indexOf(bechString.charAt(p));
+    if (d === -1) {
+      return null;
+    }
+    data.push(d);
+  }
+  if (!verifyChecksum(hrp, data)) {
+    return null;
+  }
+  return {hrp: hrp, data: data.slice(0, data.length - 6)};
+}

--- a/ref/javascript/segwit_addr.js
+++ b/ref/javascript/segwit_addr.js
@@ -1,163 +1,71 @@
-bech32 = function() {
-    var BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
-    var BECH32_GENERATOR = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+var bech32 = require('./bech32');
 
-    function polymod(values) {
-        var chk = 1;
-        for (var p = 0; p < values.length; ++p) {
-            var top = chk >> 25;
-            chk = (chk & 0x1ffffff) << 5 ^ values[p];
-            for (var i = 0; i < 5; ++i) {
-                if ((top >> i) & 1) {
-                    chk ^= BECH32_GENERATOR[i];
-                }
-            }
-        }
-        return chk;
+module.exports = {
+  encode: encode,
+  decode: decode
+};
+
+function convertbits (data, frombits, tobits, pad) {
+  var acc = 0;
+  var bits = 0;
+  var ret = [];
+  var maxv = (1 << tobits) - 1;
+  for (var p = 0; p < data.length; ++p) {
+    var value = data[p];
+    if (value < 0 || (value >> frombits) !== 0) {
+      return null;
     }
-
-
-    function hrp_expand(hrp) {
-        var ret = [];
-        for (var p = 0; p < hrp.length; ++p) {
-            ret.push(hrp.charCodeAt(p) >> 5);
-        }
-        ret.push(0);
-        for (var p = 0; p < hrp.length; ++p) {
-            ret.push(hrp.charCodeAt(p) & 31);
-        }
-        return ret;
+    acc = (acc << frombits) | value;
+    bits += frombits;
+    while (bits >= tobits) {
+      bits -= tobits;
+      ret.push((acc >> bits) & maxv);
     }
-
-    function verify_checksum(hrp, data) {
-        return polymod(hrp_expand(hrp).concat(data)) == 1
+  }
+  if (pad) {
+    if (bits > 0) {
+      ret.push((acc << (tobits - bits)) & maxv);
     }
+  } else if (bits >= frombits || ((acc << (tobits - bits)) & maxv)) {
+    return null;
+  }
+  return ret;
+}
 
-    function create_checksum(hrp, data) {
-        var values = hrp_expand(hrp).concat(data).concat([0, 0, 0, 0, 0, 0]);
-        var mod = polymod(values) ^ 1;
-        var ret = [];
-        for (var p = 0; p < 6; ++p) {
-            ret.push((mod >> 5 * (5 - p)) & 31);
-        }
-        return ret;
+function decode (hrp, addr) {
+  var hasLower = false;
+  var hasUpper = false;
+  for (var p = 0; p < addr.length; ++p) {
+    var c = addr.charAt(p);
+    if (c >= 'a' && c <= 'z') {
+      hasLower = true;
+    } else if (c >= 'A' && c <= 'Z') {
+      hasUpper = true;
+    } else if (!(c >= '0' && c <= '9')) {
+      return null;
     }
+  }
+  if (hasLower && hasUpper) {
+    return null;
+  }
+  var dec = bech32.decode(addr.toLowerCase());
+  if (dec === null || dec.hrp !== hrp || dec.data.length < 1 || dec.data[0] > 16) {
+    return null;
+  }
+  var res = convertbits(dec.data.slice(1), 5, 8, false);
+  if (res === null || res.length < 2 || res.length > 40) {
+    return null;
+  }
+  if (dec.data[0] === 0 && res.length !== 20 && res.length !== 32) {
+    return null;
+  }
+  return {version: dec.data[0], program: res};
+}
 
-    function encode(hrp, data) {
-        var combined = data.concat(create_checksum(hrp, data));
-        var ret = hrp + "1";
-        for (var p = 0; p < combined.length; ++p) {
-            ret += BECH32_CHARSET.charAt(combined[p]);
-        }
-        return ret;
-    }
-
-    function decode(bech_string) {
-        for (var p = 0; p < bech_string.length; ++p) {
-            if (bech_string.charCodeAt(p) < 32 || bech_string.charCodeAt(p) > 126) {
-                return null;
-            }
-        }
-        var pos = bech_string.lastIndexOf("1");
-        if (pos < 1 || pos + 7 > bech_string.length || bech_string.length > 90) {
-            return null;
-        }
-        var hrp = bech_string.substring(0, pos);
-        var data = [];
-        for (var p = pos + 1; p < bech_string.length; ++p) {
-            var d = BECH32_CHARSET.indexOf(bech_string.charAt(p));
-            if (d == -1) {
-                return null;
-            }
-            data.push(d);
-        }
-        if (!verify_checksum(hrp, data)) {
-            return null;
-        }
-        return {hrp: hrp, data: data.slice(0, data.length - 6)};
-    }
-
-    return {
-        encode: encode,
-        decode: decode
-    };
-}();
-
-segwit_addr = function() {
-    function convertbits(data, frombits, tobits, pad) {
-        var acc = 0;
-        var bits = 0;
-        var ret = [];
-        var maxv = (1 << tobits) - 1;
-        for (var p = 0; p < data.length; ++p) {
-            var value = data[p];
-            if (value < 0 || (value >> frombits) != 0) {
-                return null;
-            }
-            acc = (acc << frombits) | value;
-            bits += frombits;
-            while (bits >= tobits) {
-                bits -= tobits;
-                ret.push((acc >> bits) & maxv);
-            }
-        }
-        if (pad) {
-            if (bits > 0) {
-                ret.push((acc << (tobits - bits)) & maxv);
-            }
-        } else if (bits >= frombits || ((acc << (tobits - bits)) & maxv)) {
-            return null;
-        }
-        return ret;
-    }
-
-    function decode(hrp, addr) {
-        var has_lower = false;
-        var has_upper = false;
-        for (var p = 0; p < addr.length; ++p) {
-            var c = addr.charAt(p);
-            if (c >= 'a' && c <= 'z') {
-                has_lower = true;
-            } else if (c >= 'A' && c <= 'Z') {
-                has_upper = true;
-            } else if (!(c >= '0' && c <= '9')) {
-                return null;
-            }
-        }
-        if (has_lower && has_upper) {
-            return null;
-        }
-        dec = bech32.decode(addr.toLowerCase());
-        if (dec === null || dec.hrp != hrp || dec.data.length < 1 || dec.data[0] > 16) {
-            return null;
-        }
-        res = convertbits(dec.data.slice(1), 5, 8, false);
-        if (res === null || res.length < 2 || res.length > 40) {
-            return null;
-        }
-        if (dec.data[0] == 0 && res.length != 20 && res.length != 32) {
-            return null;
-        }
-        return {version: dec.data[0], program: res};
-    }
-
-    function encode(hrp, version, program) {
-        var ret = bech32.encode(hrp, [version].concat(convertbits(program, 8, 5, true)));
-        if (decode(hrp, ret) === null) {
-            return null;
-        }
-        return ret;
-    }
-
-    return {
-        decode: decode,
-        encode: encode
-    };
-}();
-
-if (typeof exports !== 'undefined') {
-    exports.bech32_encode = bech32.encode;
-    exports.bech32_decode = bech32.decode;
-    exports.encode = segwit_addr.encode;
-    exports.decode = segwit_addr.decode;
+function encode (hrp, version, program) {
+  var ret = bech32.encode(hrp, [version].concat(convertbits(program, 8, 5, true)));
+  if (decode(hrp, ret) === null) {
+    return null;
+  }
+  return ret;
 }

--- a/ref/javascript/tests.js
+++ b/ref/javascript/tests.js
@@ -1,4 +1,6 @@
+///@TODO: Use tape instead of pure js for tests, requires adding a package.json to manage to dependency
 var segwit_addr = require('./segwit_addr.js');
+var bech32 = require('./bech32');
 
 function segwit_scriptpubkey(version, program) {
     return [version ? version + 0x80 : 0, program.length].concat(program);

--- a/ref/javascript/tests.js
+++ b/ref/javascript/tests.js
@@ -76,9 +76,12 @@ var INVALID_ADDRESS = [
     "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
 ];
 
+var didPassTests = true;
+
 for (var p = 0; p < VALID_CHECKSUM.length; ++p) {
     var test = VALID_CHECKSUM[p];
     var ret = bech32.decode(test);
+    didPassTests = didPassTests && !!ret;
     console.log("Valid checksum for " + test + ": " + (ret === null ? "fail" : "ok"));
 }
 
@@ -102,11 +105,20 @@ for (var p = 0; p < VALID_ADDRESS.length; ++p) {
         var recreate = segwit_addr.encode(hrp, ret.version, ret.program);
         ok = (recreate === address.toLowerCase());
     }
+    didPassTests = didPassTests && !!ok;
     console.log("Valid address " + address + ": " + (ok ? "ok" : "FAIL"));
 }
 
 for (var p = 0; p < INVALID_ADDRESS.length; ++p) {
     var test = INVALID_ADDRESS[p];
     var ok = segwit_addr.decode("bc", test) === null && segwit_addr.decode("tb", test) === null;
+    didPassTests = didPassTests && !!ok;
     console.log("Invalid address " + test + ": " + (ok ? "ok" : "FAIL"));
+}
+
+if (!didPassTests) {
+    console.error();
+    console.error('Failed tests');
+    console.error();
+    process.exit(1);
 }


### PR DESCRIPTION
 * Format code (except for tests) to `semistandard` js coding style
   * Indentation / whitespace
   * Camel case methods and variable names
   * equals equals equals instead of equals equals
 * Break out two components into 2 files, expose module.exports in sane location on each
   * previous version used two self execution functions instead of 2 files
 * Test is unmodified except for including the files
   * this was previously broken out of the box anyway since bech32 was never defined
 * Added note about porting to a real test case package for node instead of using raw JS and outputting the result
 * Return non-zero on test fail and output a failed message at the bottom
