### PR TITLE
Segwit address error locator demo: Bootstrap 4 

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
-<head>
-<meta charset="UTF-8">
-<title>Segwit address error locator demo</title>
-</head>
-<body>
-<script src="demo.js" type="text/javascript"></script>
-<script type="text/javascript">
+    <head>
+        <meta charset="UTF-8">
+        <title>Segwit address error locator demo</title>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+    </head>
+    <body>
+        <script type="text/javascript">
 
 function update_status() {
     var address = document.getElementById("address").value;
@@ -29,10 +29,23 @@ function update_status() {
     document.getElementById("copy").innerHTML = cp;
 }
 </script>
-<h3>Segwit address demo</h3>
-<p><input type="text" id="address" size="74" oninput="update_status();" /></p>
-
-<p><a id="result"></a></p>
-<p><a id="copy"></a></p>
-</body>
+    <div class="container" style="margin-top:50px">
+            <div class="card text-left">
+                <h3 class="card-header">Segwit address demo</h3>
+                <div class="card-block">
+                    <div class="form-group row">
+                        <label for="lgFormGroupInput" class="col-sm-2 col-form-label col-form-label-lg">Adress</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control form-control-lg" id="address" placeholder="SegWit address" size="74" oninput="update_status();" />
+                        </div>
+                    </div>
+                    <p><a id="result"></a></p>
+                    <p><a id="copy"></a></p>
+                </div>
+            </div>
+        </div>
+    </body>
 </html>
+
+ <script src="demo.js" type="text/javascript"></script>
+

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -29,12 +29,13 @@ function update_status() {
             }
         }
     }
+    if(address.length === 0) document.getElementById("result").innerHTML = "";
     document.getElementById("copy").innerHTML = cp;
 }
 </script>
     <div class="container" style="margin-top:50px">
             <div class="card text-left">
-                <h3 class="card-header">Segwit address demo</h3>
+                <h3 class="card-header">SegWit address demo</h3>
                 <div class="card-block">
                     <div class="form-group row">
                         <label for="lgFormGroupInput" class="col-sm-2 col-form-label col-form-label-lg">Adress</label>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -1,8 +1,11 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <!-- Required meta tags -->
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <title>Segwit address error locator demo</title>
+        <!-- Bootstrap CSS -->
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
     </head>
     <body>
@@ -47,5 +50,4 @@ function update_status() {
     </body>
 </html>
 
- <script src="demo.js" type="text/javascript"></script>
-
+<script src="demo.js" type="text/javascript"></script>


### PR DESCRIPTION
Bootstrap 4 CDN to the html demo file.

When putting a wrong address and after that clearing the input field, the result kept showing.
I added 1 line of JS to clear the result if the input field is empty again.

 ````if(address.length === 0) document.getElementById("result").innerHTML = "";````

This is how it looks now with Bootstrap.

![screenshot from 2017-03-14 12-02-03](https://cloud.githubusercontent.com/assets/6548898/23897972/8394ec00-08af-11e7-9ba5-2f6859caba16.png)
