### PR TITLE
Cleaner version to empty the result

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -30,7 +30,7 @@ function update_status() {
             }
         }
     }
-    if(address.length === 0) document.getElementById("result").innerHTML = "";
+    if(!address.length) document.getElementById("result").innerHTML = "";
     document.getElementById("copy").innerHTML = cp;
 }
 </script>


### PR DESCRIPTION
change ````if(address.length === 0) ```` into ````if(!address.length) ````
Same effect, just a bit cleaner.
