### PR TITLE
license: Add referenced 2-Clause BSD License

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,26 @@
+The 2-Clause BSD License
+
+Copyright 2017 Peter Wuille & Greg Maxwell
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/bip-witaddr.mediawiki
+++ b/bip-witaddr.mediawiki
@@ -7,7 +7,7 @@
   Comments-URI: ???
   Status: Draft
   Type: Informational
-  Created: 2016-03-20
+  Created: 2017-03-20
   License: BSD-2-Clause
 </pre>
 
@@ -19,7 +19,7 @@ This document proposes a checksummed base32 format, "Bech32", and a standard for
 
 ===Copyright===
 
-This BIP is licensed under the 2-clause BSD license.
+This BIP is licensed under the [https://github.com/bitcoin/bips/blob/master/COPYING 2-clause BSD license].
 
 ===Motivation===
 


### PR DESCRIPTION
This adds a `COPYING` file to the repository with the 2-Clause BSD
License that is referenced in `bip-witaddr.mediawiki`. It also adds a
link back to COPYING in `bip-witaddr.mediawiki` in the aforementioned
reference.