### PR TITLE
ref/python: bound converbits accumulator

### DIFF
--- a/ref/python/segwit_addr.py
+++ b/ref/python/segwit_addr.py
@@ -83,10 +83,11 @@ def convertbits(data, frombits, tobits, pad=True):
     bits = 0
     ret = []
     maxv = (1 << tobits) - 1
+    max_acc = (1 << (frombits + tobits - 1)) - 1
     for value in data:
         if value < 0 or (value >> frombits):
             return None
-        acc = (acc << frombits) | value
+        acc = ((acc << frombits) | value) & max_acc
         bits += frombits
         while bits >= tobits:
             bits -= tobits


### PR DESCRIPTION
In the loop, acc is shifted in every iteration. Python's int is a
bigint, so acc unnecessarily grows very large.