### PR TITLE
hrp is ASCII character, not 5 bit words

### DIFF
--- a/ref/c/segwit_addr.c
+++ b/ref/c/segwit_addr.c
@@ -51,9 +51,13 @@ int bech32_encode(char *output, const char *hrp, const uint8_t *data, size_t dat
     uint32_t chk = 1;
     size_t i = 0;
     while (hrp[i] != 0) {
-        if (hrp[i] >= 'A' && hrp[i] <= 'Z') return 0;
-        if (!(hrp[i] >> 5)) return 0;
-        chk = bech32_polymod_step(chk) ^ (hrp[i] >> 5);
+        int ch = hrp[i];
+        if (ch < 33 || ch > 126) {
+            return 0;
+        }
+
+        if (ch >= 'A' && ch <= 'Z') return 0;
+        chk = bech32_polymod_step(chk) ^ (ch >> 5);
         ++i;
     }
     if (i + 7 + data_len > 90) return 0;


### PR DESCRIPTION
As discussed over IRC

> The human-readable part, which is intended to convey the type of data or anything else that is relevant for the reader. Its validity (including the used set of characters) is application specific, but restricted to ASCII characters with values in the range 33-126.

[Ref](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32)

Example: `abc\x0` can be encoded, but not decoded