### PR TITLE
Update Rust tests

### DIFF
--- a/ref/rust/src/lib.rs
+++ b/ref/rust/src/lib.rs
@@ -149,6 +149,38 @@ mod tests {
     }
 
     #[test]
+    fn invalid_bech32() {
+        let pairs: Vec<(&str, CodingError)> = vec!(
+            (" 1nwldj5",
+                CodingError::InvalidChar),
+            ("\x7f1axkwrx",
+                CodingError::InvalidChar),
+            ("an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+                CodingError::InvalidLength),
+            ("pzry9x0s0muk",
+                CodingError::MissingSeparator),
+            ("1pzry9x0s0muk",
+                CodingError::InvalidLength),
+            ("x1b4n0q5v",
+                CodingError::InvalidChar),
+            ("li1dgmt3",
+                CodingError::InvalidLength),
+            ("de1lg7wt\u{ff}",
+                CodingError::InvalidChar),
+        );
+        for p in pairs {
+            let (s, expected_error) = p;
+            let dec_result = bech32::Bech32::from_string(s.to_string());
+            println!("{:?}", s.to_string());
+            if dec_result.is_ok() {
+                println!("{:?}", dec_result.unwrap());
+                panic!("Should be invalid: {:?}", s);
+            }
+            assert_eq!(dec_result.unwrap_err(), expected_error);
+        }
+    }
+
+    #[test]
     fn valid_address() {
         let pairs: Vec<(&str, Vec<u8>)> = vec![
             (


### PR DESCRIPTION
Similar updates in the vein of #27, #29, #30, #31, #32

Adds invalid Bech32 string test cases.

Please note: Rust strings are UTF-8, so that the character literal `0xff` [turns into](https://codepoints.net/U+00FF) `0xc3bf` when accessed with the `bytes` function.