### PR TITLE
Update tests.py

### DIFF
--- a/ref/python/tests.py
+++ b/ref/python/tests.py
@@ -113,7 +113,7 @@ class TestSegwitAddress(unittest.TestCase):
                 witver, witprog = segwit_addr.decode(hrp, address)
             self.assertIsNotNone(witver)
             scriptpubkey = segwit_scriptpubkey(witver, witprog)
-            self.assertEqual(scriptpubkey, binascii.unhexlify(hexscript))
+            self.assertEqual(scriptpubkey, bytes([int(elem.encode("hex"),16) for elem in binascii.unhexlify(hexscript)]))
             addr = segwit_addr.encode(hrp, witver, witprog)
             self.assertEqual(address.lower(), addr)
 


### PR DESCRIPTION
I had to change line 116 to get the assert to compare properly.   They were "equal", but in different types.   

The left had side was a string array of 99 characters: "[0, 20, 117, 30, 118, 232, 25, 145, 150, 212, 84, 148, 28, 69, 209, 179, 163, 35, 241, 67, 59, 214]"

The right hand side was a 22 character string: \x00\x14u\x1ev\xe8\x19\x91\x96\xd4T\x94\x1cE\xd1\xb3\xa3#\xf1C;\xd6

Runnings tests.py gave me the following before the proposed change:

FAIL: test_valid_address (__main__.TestSegwitAddress)
Test whether valid addresses decode to the correct output.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests.py", line 118, in test_valid_address
    self.assertEqual(scriptpubkey, binascii.unhexlify(hexscript))
AssertionError: '[0, 20, 117, 30, 118, 232, 25, 145, 150, 212, 84, 148, 28, 69, 209, 179, 163, 35, 241, 67, 59, 214]' != '\x00\x14u\x1ev\xe8\x19\x91\x96\xd4T\x94\x1cE\xd1\xb3\xa3#\xf1C;\xd6'

----------------------------------------------------------------------
Ran 5 tests in 0.016s

With the change I get:
>python tests.py
.....
----------------------------------------------------------------------
Ran 5 tests in 0.016s

OK