### PR TITLE
Fix Ruby implementation for non-v0 witnesses

### DIFF
--- a/ref/ruby/segwit_addr.rb
+++ b/ref/ruby/segwit_addr.rb
@@ -37,7 +37,7 @@ class SegwitAddr
 
   def scriptpubkey=(script)
     values = [script].pack('H*').unpack("C*")
-    @ver = values[0]
+    @ver = values[0] == 0 ? values[0] : values[0] - 0x50
     @prog = values[2..-1]
   end
 

--- a/ref/ruby/test_bech32.rb
+++ b/ref/ruby/test_bech32.rb
@@ -92,6 +92,11 @@ class TestBech32 < Test::Unit::TestCase
       assert_not_nil(segwit_addr.ver)
       assert_equal(hex, segwit_addr.to_scriptpubkey)
       assert_equal(addr.downcase, segwit_addr.addr)
+      # test from hex
+      segwit_addr = SegwitAddr.new
+      segwit_addr.hrp = addr[0..1].downcase
+      segwit_addr.scriptpubkey = hex
+      assert_equal(addr.downcase, segwit_addr.addr)
     end
   end
 


### PR DESCRIPTION
When parsing version from scriptPubkey, consideration of OP1 ~ OP16 was missing and it was fixed.