### PR TITLE
Fix a buffer overflow in the C reference decoder

### DIFF
--- a/ref/c/segwit_addr.c
+++ b/ref/c/segwit_addr.c
@@ -97,7 +97,7 @@ int bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input)
         ++(*data_len);
     }
     hrp_len = input_len - (1 + *data_len);
-    if (hrp_len < 1 || *data_len < 6) {
+    if (1 + *data_len >= input_len || *data_len < 6) {
         return 0;
     }
     *(data_len) -= 6;

--- a/ref/c/tests.c
+++ b/ref/c/tests.c
@@ -91,6 +91,7 @@ static const char* invalid_address[] = {
     "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
     "bc1rw5uspcuh",
     "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+    "bca0w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90234567789035",
     "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
     "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
     "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",


### PR DESCRIPTION
Thanks to Christian Reitter and @jhoenicke for discovering this issue and suggesting a fix.
