### PR TITLE
html validation ok on https://validator.w3.org

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <!-- Required meta tags -->
         <meta charset="UTF-8">
@@ -19,7 +19,7 @@
         </style>
     </head>
     <body>
-        <script type="text/javascript">
+        <script>
 
 function toHexString(byteArray) {
   return byteArray.map(function(byte) {
@@ -81,13 +81,13 @@ function load_addr(addr) {
                 <h3 class="card-header">Decoder demo</h3>
                 <div class="card-block">
                     <div class="form-group row">
-                        <label for="lgFormGroupInput" class="col-sm-2 col-form-label col-form-label-lg">Address</label>
+                        <label for="address" class="col-sm-2 col-form-label col-form-label-lg">Address</label>
                         <div class="col-sm-10">
                             <input type="text" class="form-control form-control-lg monospace" id="address" placeholder="SegWit address" size="74" oninput="update_status();" />
                         </div>
                     </div>
-                    <p><a id="result"><br/></a></p>
-                    <p><span class="monospace"><a id="copy"><br/></a></span></p>
+                    <p><span id="result"><br/></span></p>
+                    <p><span id="copy" class="monospace"><br/></span></p>
                     Fill field with:
                     <ul>
                     <li> <a class="demo_link" href='javascript:load_addr("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");'>P2WPKH example</a>
@@ -100,10 +100,10 @@ function load_addr(addr) {
 
     <footer class="footer">
         <div class="container text-center">
-            <img height="80px" src="SegWit.png" width="288px">
+            <img height="80" src="SegWit.png" width="288" alt="SegWit">
         </div>
     </footer>
+    <script src="demo.js"></script>
     </body>
 </html>
 
-<script src="demo.js" type="text/javascript"></script>


### PR DESCRIPTION
Resolve these static HTML validation issues on https://validator.w3.org:
- Warning: Consider adding a `lang` attribute to the html start tag to declare the language of this document;
- Warning: The type attribute is unnecessary for JavaScript resources;
- Error: Bad value 80px for attribute height on element img: Expected a digit but saw p instead.
- Error: Bad value 288px for attribute width on element img: Expected a digit but saw p instead.
- Error: An img element must have an alt attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.
- Error: Stray start tag script.
- Warning: The type attribute is unnecessary for JavaScript resources.
- Error: The value of the `for` attribute of the label element must be the ID of a non-hidden form control.

and runtime HTML validation issues, where the `result` and `copy` dom were an `a` tag inside another `a` tag.
