### PR TITLE
Convert HRP to lower-case before calculating checksum within `bech32Encode`

### DIFF
--- a/ref/haskell/src/Codec/Binary/Bech32.hs
+++ b/ref/haskell/src/Codec/Binary/Bech32.hs
@@ -80,9 +80,10 @@ bech32VerifyChecksum hrp dat = bech32Polymod (bech32HRPExpand hrp ++ dat) == 1
 bech32Encode :: HRP -> [Word5] -> Maybe BS.ByteString
 bech32Encode hrp dat = do
     guard $ checkHRP hrp
-    let dat' = dat ++ bech32CreateChecksum hrp dat
+    let hrpLower = BSC.map toLower hrp
+        dat' = dat ++ bech32CreateChecksum hrpLower dat
         rest = map (charset Arr.!) dat'
-        result = BSC.concat [BSC.map toLower hrp, BSC.pack "1", BSC.pack rest]
+        result = BSC.concat [hrpLower, BSC.pack "1", BSC.pack rest]
     guard $ BS.length result <= 90
     return result
 

--- a/ref/haskell/test/Spec.hs
+++ b/ref/haskell/test/Spec.hs
@@ -113,6 +113,6 @@ tests = testGroup "Tests"
           assertBool "empty HRP encode" $ isNothing $ bech32Encode (BSC.pack "") []
           assertBool "empty HRP decode" $ isNothing $ bech32Decode (BSC.pack "10a06t8")
           assertEqual "hrp lowercased"
-              (Just $ BSC.pack "hrp1g9xj8m")
+              (Just $ BSC.pack "hrp1vhqs52")
               (bech32Encode (BSC.pack "HRP") [])
     ]


### PR DESCRIPTION
This change fixes issue 49 (https://github.com/sipa/bech32/issues/49).

As part of this fix, we also update the test suite with the correct encoding for the upper-case HRP example.