### PR TITLE
Remove static on convert_bits

### DIFF
--- a/ref/c/segwit_addr.c
+++ b/ref/c/segwit_addr.c
@@ -140,7 +140,7 @@ int bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input)
     return chk == 1;
 }
 
-static int convert_bits(uint8_t* out, size_t* outlen, int outbits, const uint8_t* in, size_t inlen, int inbits, int pad) {
+int convert_bits(uint8_t* out, size_t* outlen, int outbits, const uint8_t* in, size_t inlen, int inbits, int pad) {
     uint32_t val = 0;
     int bits = 0;
     uint32_t maxv = (((uint32_t)1) << outbits) - 1;

--- a/ref/c/segwit_addr.h
+++ b/ref/c/segwit_addr.h
@@ -89,7 +89,7 @@ int bech32_encode(
  *       data_len: Pointer to a size_t that will be updated to be the number
  *                 of entries in data.
  *  In: input:     Pointer to a null-terminated Bech32 string.
- *  Returns 1 if succesful.
+ *  Returns 1 if successful.
  */
 int bech32_decode(
     char *hrp,
@@ -97,5 +97,17 @@ int bech32_decode(
     size_t *data_len,
     const char *input
 );
+
+/** Change bit encoding 
+ *  Out: out: pointer to a buffer containing re-encoded data
+ *       outlen: pointer the length of the output buffer
+ *  In:  outbits: bit length of the encoded output 
+ *       in: pointer to a buffer containing data to be encoded
+ *       inlen: length of the input buffer
+ *       inbits: bit length of the input
+ *       pad: enable padding
+ *  Returns 1 if successful.
+ */
+int convert_bits(uint8_t* out, size_t* outlen, int outbits, const uint8_t* in, size_t inlen, int inbits, int pad);
 
 #endif


### PR DESCRIPTION
Dear all,

I'm working on a C implementation of [age](https://github.com/FiloSottile/age) and I need access to the internal `convert_bits` function which is declared static.
This pr enables that.

Happy new year,
Carlo 