### PR TITLE
Update for Haskell's base16 decoder.

### DIFF
--- a/ref/haskell/test/Spec.hs
+++ b/ref/haskell/test/Spec.hs
@@ -64,8 +64,7 @@ invalidAddresses = map BSC.pack
     ]
 
 hexDecode :: BS.ByteString -> BS.ByteString
-hexDecode s = let (ret, rest) = B16.decode s
-              in if BS.null rest then ret else undefined
+hexDecode s = either error id $ B16.decode s
 
 segwitScriptPubkey :: Word8 -> [Word8] -> BS.ByteString
 segwitScriptPubkey witver witprog = BS.pack $ witver' : (fromIntegral $ length witprog) : witprog


### PR DESCRIPTION
As of version 1.0.0 the signature for Data.ByteString.Base16.decode has been changed.
This requires an update for the Haskell testsuite to be able to build.